### PR TITLE
SUB-306 Upgrade solution to .NET 10

### DIFF
--- a/LoggingMicroservice/Directory.Build.props
+++ b/LoggingMicroservice/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <CodeAnalysisRuleSet>..\stylecop.ruleset</CodeAnalysisRuleSet>

--- a/LoggingMicroservice/LoggingMicroservice.API.UnitTests/LoggingMicroservice.API.UnitTests.csproj
+++ b/LoggingMicroservice/LoggingMicroservice.API.UnitTests/LoggingMicroservice.API.UnitTests.csproj
@@ -12,7 +12,7 @@
         </PackageReference>
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="ILogger.Moq" Version="2.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="MSTest.TestAdapter" Version="3.10.4" />

--- a/LoggingMicroservice/LoggingMicroservice.API/Dockerfile
+++ b/LoggingMicroservice/LoggingMicroservice.API/Dockerfile
@@ -1,4 +1,4 @@
-﻿FROM defradigital/dotnetcore-development:dotnet8.0 AS build-env
+﻿FROM defradigital/dotnetcore-development:dotnet10.0 AS build-env
 USER root
 # Expose the app on a defined port, configurable via a build argument
 ARG PORT=3000
@@ -18,7 +18,7 @@ WORKDIR /home/dotnet/LoggingMicroservice.API
 RUN dotnet publish -c Release -o out
 
 # Build runtime image
-FROM defradigital/dotnetcore:dotnet8.0
+FROM defradigital/dotnetcore:dotnet10.0
 
 # Switch to the non-root user
 USER dotnet

--- a/LoggingMicroservice/LoggingMicroservice.API/LoggingMicroservice.API.csproj
+++ b/LoggingMicroservice/LoggingMicroservice.API/LoggingMicroservice.API.csproj
@@ -9,13 +9,10 @@
         <PackageReference Include="Asp.Versioning.Mvc" Version="8.1.0" />
         <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
         <PackageReference Include="Azurite" Version="2.6.5" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.7" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.7" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
         <PackageReference Include="Microsoft.Extensions.Azure" Version="1.10.0" />
-        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
         <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.6.2" />
         <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="8.0.2" />

--- a/pipelines/ci_pipeline.yaml
+++ b/pipelines/ci_pipeline.yaml
@@ -17,7 +17,7 @@ parameters:
     # - 'SonarQubeLatest'
 
 
-pool: DEFRA-COMMON-ubuntu2004-SSV3
+pool: DEFRA-COMMON-UBUNTU-SSV3
 
 variables:
   - template: vars/DEV4-development.yaml
@@ -36,7 +36,7 @@ variables:
   - name: runTests
     value: true
   - name: dotnetVersion
-    value: dotnetVersion8
+    value: dotnetVersion10
 
 resources:
   repositories:

--- a/pipelines/deployment-pipeline.yaml
+++ b/pipelines/deployment-pipeline.yaml
@@ -1,6 +1,6 @@
 trigger: none
 pr: none
-pool: DEFRA-COMMON-ubuntu2004-SSV3
+pool: DEFRA-COMMON-UBUNTU-SSV3
 appendCommitMessageToRunName: false
 name: 'Deploy code to $(serviceName)'
 


### PR DESCRIPTION
- Bump TargetFramework from net8.0 to net10.0 in Directory.Build.props
- Upgrade Microsoft.AspNetCore.Authentication.JwtBearer and Microsoft.EntityFrameworkCore to 10.0.0
- Upgrade Microsoft.Extensions.Caching.Memory to 10.0.0 in test project
- Remove Microsoft.Extensions.Caching.Memory, Microsoft.Extensions.DependencyInjection, and Microsoft.Extensions.Options.ConfigurationExtensions references (now provided transitively by the Web SDK shared framework in .NET 10)
- Switch Dockerfile base images to  defradigital/dotnetcore*:dotnet10.0
- Update CI/deployment pipelines: dotnetVersion10 and enable the use of the new build agents